### PR TITLE
add s3 notifications to cloudfront log bucket

### DIFF
--- a/config/dev/regional/s3.yaml
+++ b/config/dev/regional/s3.yaml
@@ -8,3 +8,7 @@ parameters:
   SsmPath: !stack_attr sceptre_user_data.ssm_path
 
   LogBucketObjectLifeSpan: '30'
+
+  # sqs queue must be available before trying to configure it here
+  S3LogsEventNotificationQueueArn: !stack_output_external uc3-ops-dev-osis-pipelines::Uc3OpsOsisPipelineSqsQueue
+

--- a/templates/s3.yaml
+++ b/templates/s3.yaml
@@ -14,9 +14,22 @@ Parameters:
     Type: 'Number'
     Default: 30
 
+  # sqs queue must be available before trying to configure it here
+  S3LogsEventNotificationQueueArn:
+    Type: 'String'
+    Default: ""
+
+
 Conditions:
   PreventDelete:
     !Equals [!Ref Env, 'prd']
+
+  # If sqs queue is not defined, do not configure log event notifications
+  SetLogsEventNotifications: !Not
+    - !Equals 
+      - !Ref S3LogsEventNotificationQueueArn
+      - ''
+
 
 Resources:
   # ----------------------------------------------
@@ -44,6 +57,15 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      NotificationConfiguration:
+        !If
+          - SetLogsEventNotifications
+          -
+            QueueConfigurations:
+              - Event: s3:ObjectCreated:*
+                Queue: !Ref S3LogsEventNotificationQueueArn
+          - {}
+
 
   # S3 Bucket that stores DMP documents and UI resources. It is not directly public, but is
   # instead server through the CloudFront Distribution


### PR DESCRIPTION
Log events written to the log bucket notify a osis pipeline sqs queue to trigger log ingestion to opensearch.