### PR TITLE
added ICMU lifecycle policies to all buckets

### DIFF
--- a/templates/s3.yaml
+++ b/templates/s3.yaml
@@ -33,8 +33,13 @@ Resources:
     Properties:
       LifecycleConfiguration:
         Rules:
-          - ExpirationInDays: !Ref LogBucketObjectLifeSpan
+          - Id: 'LogLifespan'
+            ExpirationInDays: !Ref LogBucketObjectLifeSpan
             Status: 'Enabled'
+          - Id: 'ICMU'
+            Status: 'Enabled'
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 5
       AccessControl: 'Private'
       OwnershipControls:
         Rules:
@@ -67,6 +72,12 @@ Resources:
         LogFilePrefix: 's3-access'
       VersioningConfiguration:
         Status: 'Enabled'
+      LifecycleConfiguration:
+        Rules:
+          - Id: 'ICMU'
+            Status: 'Enabled'
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 5
 
   # S3 Bucket for storing things that should not be publicly accessible like CodePipeline artifacts
   S3PrivateBucket:
@@ -85,6 +96,12 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref S3LogBucket
         LogFilePrefix: 's3-access'
+      LifecycleConfiguration:
+        Rules:
+          - Id: 'ICMU'
+            Status: 'Enabled'
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 5
 
   # S3 Bucket for transferring files between our AWS cloud environ and external systems
   S3FileExchangeBucket:
@@ -99,10 +116,14 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # The DMPTool <--> COKI integration occurs once per week, so only need to retain files for 6 days
-          - Id: CokiRule
-            Prefix: coki
-            Status: Enabled
+          - Id: 'CokiRule'
+            Prefix: 'coki'
+            Status: 'Enabled'
             ExpirationInDays: 6
+          - Id: 'ICMU'
+            Status: 'Enabled'
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 5
       LoggingConfiguration:
         DestinationBucketName: !Ref S3LogBucket
         LogFilePrefix: 's3-access'


### PR DESCRIPTION
Adding lifecycle policies to all DMP Hub S3 buckets to deal with phantom multi-part upload failure artifacts. IAS discovered that when a multi-part upload fails, the parts that were part of the process get stuck and sit in the bucket and we get charged for them. The fun part is that they are not visible via the console or CLI, so we can't manually delete them! AWS finally added a way for us to setup a lifecycle to clean them up. See [#39](https://github.com/CDLUC3/dmptool-infrastructure/issues/39)