### PR TITLE
Update CloudFront Lambda to work with new esbuild Landing Page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - S3 bucket for use when transferring files between our AWS cloud environ to/from COKI's Google cloud
 
 ### Updated
+- Update the Cloudfront distribution Lambda function to work with new landing page file layout
 - Updated JWT TTL for `ecs-backend`
 - Removed `JwtSecret`from `ecs-frontend`
 - Updated the `ecs-backend.yaml` Sceptre config and template to include the Elasticache Host and Port and also a bunch of new bcrypt, crypto, NODE_ENV and jwt ENV variables

--- a/config/stg/regional/s3.yaml
+++ b/config/stg/regional/s3.yaml
@@ -3,6 +3,8 @@ template:
   type: file
 
 parameters:
+  VpcId: !stack_attr sceptre_user_data.vpc_id
+
   Env: !stack_attr sceptre_user_data.env
 
   SsmPath: !stack_attr sceptre_user_data.ssm_path

--- a/templates/cloudfront.yaml
+++ b/templates/cloudfront.yaml
@@ -84,7 +84,8 @@ Resources:
 
             // 1. If the request is for an actual file (contains a extension dot like .json, .png, .js, .css, .ico),
             // let it pass straight through to S3 untouched.
-            if (uri.indexOf('.') !== -1) {
+            var lastSegment = uri.split('/').pop();
+            if (lastSegment.indexOf('.') !== -1) {
                 return request;
             }
 

--- a/templates/cloudfront.yaml
+++ b/templates/cloudfront.yaml
@@ -79,24 +79,30 @@ Resources:
         //   See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html
 
         function handler(event) {
-          var request = event.request;
+            var request = event.request;
+            var uri = request.uri;
 
-          // React is deployed to the `/dmps/` directory but will reference it's dependencies as if it was in the root
-          if (request.uri.includes('static/') && !request.uri.includes('dmps/')) {
-            var response = {
-              statusCode: 302,
-              statusDescription: 'Found',
-              headers: { "location": { "value": request.uri.replace('static/', 'dmps/static/') } }
-            };
-            return response;
+            // 1. If the request is for an actual file (contains a extension dot like .json, .png, .js, .css, .ico),
+            // let it pass straight through to S3 untouched.
+            if (uri.indexOf('.') !== -1) {
+                return request;
+            }
 
-          } else if (request.uri.endsWith('/api-docs') || request.uri.endsWith('/api-docs/')) {
-            request.uri += request.uri.endsWith('/') ? 'index.html' : '/index.html';
+            // 2. API Docs handler (Kept from your original logic)
+            if (uri.endsWith('/api-docs') || uri.endsWith('/api-docs/')) {
+                request.uri += uri.endsWith('/') ? 'index.html' : '/index.html';
+                return request;
+            }
+
+            // 3. Single Page Application (SPA) Deep Link Routing
+            // If a user clicks a DOI link (e.g., /dmps/doi/123) or lands on the subfolder base (/dmps/),
+            // internally map them directly onto your main index.html file.
+            if (uri.startsWith('/dmps')) {
+                request.uri = '/dmps/index.html';
+                return request;
+            }
+
             return request;
-
-          } else {
-            return request;
-          }
         }
       FunctionConfig:
         Runtime: 'cloudfront-js-1.0'


### PR DESCRIPTION
The file layout changed slightly with the migration of the Landing Page site over to esbuild. This change makes sure the assets and other calls find the files.